### PR TITLE
修复使用了RandomCopyMove没有对label进行对应修改的bug

### DIFF
--- a/IMDLBenCo/datasets/abstract_dataset.py
+++ b/IMDLBenCo/datasets/abstract_dataset.py
@@ -91,6 +91,11 @@ class AbstractDataset(Dataset):
             res_dict = self.common_transforms(image = tp_img, mask = gt_img)
             tp_img = res_dict['image']
             gt_img = res_dict['mask']
+            # copy_move may cause the label change, so we need to update the label
+            if np.all(gt_img == 0):
+                label = 0
+            else:
+                label = 1
             
         # redefine the shape, here is np.array
         tp_shape = tp_img.shape[0:2]  # H, W, 3 去掉最后一个3

--- a/IMDLBenCo/datasets/jpeg_dataset.py
+++ b/IMDLBenCo/datasets/jpeg_dataset.py
@@ -92,6 +92,11 @@ class MetaCatnetDataset(AbstractDataset):
             res_dict = self.common_transforms(image = tp_img, mask = gt_img)
             tp_img = res_dict['image']
             gt_img = res_dict['mask']
+            # copy_move may cause the label change, so we need to update the label
+            if np.all(gt_img == 0):
+                label = 0
+            else:
+                label = 1
         
         gt_img =  (np.mean(gt_img, axis = 2, keepdims = True)  > 127.5 ) * 1.0 # fuse the 3 channels to 1 channel, and make it binary(0 or 1)
         gt_img =  gt_img.transpose(2,0,1)[0] # H W C -> C H W -> H W


### PR DESCRIPTION
如果对真实图片进行了RandomCopyMove，那么这张图片的label（image-level）应该修改为forged

不对api做过多改动，直接对最终的mask进行判断，如果不是全0，那么label就设置为0

![image](https://github.com/user-attachments/assets/c53d01e1-3be8-4c26-82ab-c056d0d0a4b5)

max测试10,0000张图片对性能影响：

```python
from IMDLBenCo.transforms.iml_transforms import RandomCopyMove
from PIL import Image
import numpy as np
import matplotlib.pyplot as plt
import albumentations as A
import time


def function_timer(func):
    def wrapper(*args, **kwargs):
        start_time = time.time()
        result = func(*args, **kwargs)
        end_time = time.time()
        print(f'{func.__name__} cost time: {end_time - start_time:.4f}s')
        return result
    return wrapper


@function_timer
def do_rand_copy_move(show = False,times = 10,with_max = False):
    image_dir = 'images'

    true_file = 'true.jpg'


    image = Image.open(f'{image_dir}/{true_file}')

    image = np.array(image)

    mask = np.zeros_like(image)
    transform = A.Compose([
    RandomCopyMove(),])

    plt.figure(figsize=(10, 10))
    for i in range(times):
        # 变换
        transformed = transform(image=image, mask=mask)

        # 获取，显示
        transformed_image = transformed['image']
        transformed_mask = transformed['mask']

        if with_max:
            is_fake = False if np.all(transformed_mask == 0) else True

        if show:
            plt.subplot(times,3, i*3+1)
            plt.imshow(transformed_image)
            plt.subplot(times,3, i*3+2)
            plt.imshow(transformed_mask)
            plt.subplot(times,3, i*3+3)


            # 任意一个等于255就是使用了

            if is_fake:
                plt.text(0.5, 0.5, 'fake', fontsize=12, ha='center')

            else:
                plt.text(0.5, 0.5, 'true', fontsize=12, ha='center',color='red')

            # 去除坐标轴
            plt.axis('off')

    if show:
        # 调整图像
        plt.tight_layout()
        plt.show()



if __name__ == '__main__':
    print('###########with max############')
    do_rand_copy_move(show=False,times=100000,with_max=True)
    print('###########without max############')
    do_rand_copy_move(show=False,times=100000,with_max=False)

```



![image](https://github.com/user-attachments/assets/938e2afb-607c-487a-85cd-a62a5d7dee22)




